### PR TITLE
Remove git conflict marker

### DIFF
--- a/configuration_examples/docker-compose/production.yml
+++ b/configuration_examples/docker-compose/production.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 version: '2'
 services:
   thumbor:


### PR DESCRIPTION
`<<<<<<< HEAD` seems to have crept in during a git merge/rebase with conflicts
