### PR TITLE
Use newer gifsicle from backports repo

### DIFF
--- a/thumbor/system-requirements.txt
+++ b/thumbor/system-requirements.txt
@@ -8,5 +8,5 @@ graphicsmagick
 libgraphicsmagick++3
 libgraphicsmagick3
 libboost-python-dev
-gifsicle
+gifsicle=1.88*
 ffmpeg


### PR DESCRIPTION
Browsing mediawiki's Phabricator I found that they upgraded gifsicle to 1.88 due to some issues with older versions. https://phabricator.wikimedia.org/T151455

I noticed on apsl/thumbor image newer gifsicle is available from backports repo, but was not installed, probably due to version priorities (?), so pinning works.