### PR TITLE
Moving pypiserver to use native docker network for building images

### DIFF
--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -1,12 +1,5 @@
 version: '2'
 services:
-  pypiserver:
-    image: jcsaaddupuy/pypiserver
-    #command: pypi-server -P '' -u ''
-    volumes: 
-      - "./wheelhouse:/data/packages"
-    ports:
-      - "0.0.0.0:9009:8080"
   thumbor:
     image: apsl/thumbor
     env_file: .travis.env

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.11.5
 MAINTAINER Edu Herraiz <ghark@gmail.com>
 
 COPY nginx.conf /etc/nginx/
-COPY ./docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx-daemon"]

--- a/remotecv/Dockerfile
+++ b/remotecv/Dockerfile
@@ -18,12 +18,10 @@ ENV SHELL bash
 ENV WORKON_HOME /usr/src/app
 WORKDIR /usr/src/app
 
-ARG DOCKERHOST=172.17.0.1
-ENV DOCKERHOST ${DOCKERHOST}
 COPY requirements.txt /usr/src/app/requirements.txt
 RUN pip install --trusted-host None --no-cache-dir --use-wheel \
-   --extra-index-url http://${DOCKERHOST}:9009/simple/ \
-   --trusted-host ${DOCKERHOST} \
+   --extra-index-url http://pypiserver:8080/simple/ \
+   --trusted-host pypiserver \
    -r /usr/src/app/requirements.txt
 
 RUN \ 

--- a/thumbor-multiprocess/Dockerfile
+++ b/thumbor-multiprocess/Dockerfile
@@ -2,12 +2,10 @@ FROM apsl/thumbor
 
 MAINTAINER Edu Herraiz <ghark@gmail.com>
 
-ARG DOCKERHOST=172.17.0.1
-ENV DOCKERHOST ${DOCKERHOST}
 COPY requirements.txt /usr/src/app/requirements.txt
 RUN pip install --trusted-host None --no-cache-dir --use-wheel \
-   --extra-index-url http://${DOCKERHOST}:9009/simple/ \
-   --trusted-host ${DOCKERHOST} \
+   --extra-index-url http://pypiserver:8080/simple/ \
+   --trusted-host pypiserver \
    -r /usr/src/app/requirements.txt
 
 ADD conf/circus.ini.tpl /etc/

--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -19,12 +19,10 @@ ENV SHELL bash
 ENV WORKON_HOME /usr/src/app
 WORKDIR /usr/src/app
 
-ARG DOCKERHOST=172.17.0.1
-ENV DOCKERHOST ${DOCKERHOST}
 COPY requirements.txt /usr/src/app/requirements.txt
 RUN pip install --trusted-host None --no-cache-dir --use-wheel \
-   --extra-index-url http://${DOCKERHOST}:9009/simple/ \
-   --trusted-host ${DOCKERHOST} \
+   --extra-index-url http://pypiserver:8080/simple/ \
+   --trusted-host pypiserver \
    -r /usr/src/app/requirements.txt
 
 COPY conf/thumbor.conf.tpl /usr/src/app/thumbor.conf.tpl


### PR DESCRIPTION
This fixes #41. This change  should allow the ./builder script to work on any docker engine by leveraging a custom native docker network for the builds using with the pypiserver instead of exposing ports through the host network.

My steps fo testing: 
- `./builder`
- `docker run -it -p 8000:8000 apsl/thumbor`
- ` visit http://localhost:8000/unsafe/1000x/http://s2.quickmeme.com/img/8f/8fe15572b1396f4d97276aaf3f407a7a5f23e50cd5489b4f167c83b901717744.jpg