### PR TITLE
Add support for the TC_AWS_ENDPOINT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Env vars and default value:
     ERROR_FILE_NAME_USE_CONTEXT='False'
     SENTRY_DSN_URL=''
     TC_AWS_REGION='eu-west-1'
+    TC_AWS_ENDPOINT=None
     TC_AWS_STORAGE_BUCKET=''
     TC_AWS_STORAGE_ROOT_PATH=''
     TC_AWS_LOADER_BUCKET=''

--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -629,6 +629,8 @@ APP_CLASS = '{{ APP_CLASS | default('thumbor.app.ThumborServiceApp') }}'
 ############################## TC_AWS ##########################################
 TC_AWS_REGION = '{{ TC_AWS_REGION | default('eu-west-1') }}' # AWS Region
 
+TC_AWS_ENDPOINT = {{ TC_AWS_ENDPOINT if TC_AWS_ENDPOINT | default(None) else None }} # Custom S3 endpoint URL (for GCP, Minio, etc.)
+
 TC_AWS_STORAGE_BUCKET = '{{ TC_AWS_STORAGE_BUCKET | default('') }}' # S3 bucket for Storage
 TC_AWS_STORAGE_ROOT_PATH = '{{ TC_AWS_STORAGE_ROOT_PATH | default('') }}' # S3 path prefix for Storage bucket
 


### PR DESCRIPTION
Allows using Thumbor with other S3-compatible services, such as:
- Minio
- Google Cloud Platform's storage system