### PR TITLE
fixed REDIS_* env vars to REMOTECV_REDIS_* in examples

### DIFF
--- a/configuration_examples/docker-compose/lazy-detector.yml
+++ b/configuration_examples/docker-compose/lazy-detector.yml
@@ -37,9 +37,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
     networks:
       - app
   redis:

--- a/configuration_examples/docker-compose/production-swarm.yml
+++ b/configuration_examples/docker-compose/production-swarm.yml
@@ -51,9 +51,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
       - SENTRY_URL= # put your sentry enpoint here
       - LOADER=remotecv_aws.loader
       - AWS_ACCESS_KEY_ID= # put your AWS_ACCESS_KEY here

--- a/configuration_examples/docker-compose/production.yml
+++ b/configuration_examples/docker-compose/production.yml
@@ -51,9 +51,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
       - SENTRY_URL= # put your sentry enpoint here
       - REMOTECV_LOADER=remotecv_aws.loader
       - AWS_ACCESS_KEY_ID= # put your AWS_ACCESS_KEY here

--- a/configuration_examples/google_cloud_engine/production/remotecv-rc.yaml
+++ b/configuration_examples/google_cloud_engine/production/remotecv-rc.yaml
@@ -21,11 +21,11 @@ spec:
         - name: remotecv
           image: apsl/remotecv:latest
           env:
-          - name: REDIS_HOST
+          - name: REMOTECV_REDIS_HOST
             value: redis
-          - name: REDIS_PORT
+          - name: REMOTECV_REDIS_PORT
             value: "6379"
-          - name: REDIS_DATABASE
+          - name: REMOTECV_REDIS_DATABASE
             value: "11"
           - name: AWS_ACCESS_KEY_ID
             value: "MY_AWS_ACCESS_KEY_ID"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -40,9 +40,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
     networks:
       - app
   redis:

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -89,9 +89,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
     networks:
       - app
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
     networks:
       - app
   redis:

--- a/tutum.yml
+++ b/tutum.yml
@@ -37,9 +37,9 @@ services:
     links:
       - redis:redis
     environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DATABASE=0
+      - REMOTECV_REDIS_HOST=redis
+      - REMOTECV_REDIS_PORT=6379
+      - REMOTECV_REDIS_DATABASE=0
     networks:
       - app
 volumes:


### PR DESCRIPTION
Examples and docker compose configs use obsolete env variables which were renamed around #35.

Nobody noticed that earlier probably because configs set env vars to default values (`redis:6379`), but when you try to use custom redis server, examples are misleading.

I've fixed every usage of `REDIS_*` to `REMOTECV_REDIS_*`.