### PR TITLE
changing default value of loader bucket 

### DIFF
--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -646,7 +646,7 @@ TC_AWS_ENDPOINT = {{ TC_AWS_ENDPOINT | default(None) }} # Custom S3 endpoint URL
 TC_AWS_STORAGE_BUCKET = '{{ TC_AWS_STORAGE_BUCKET | default('') }}' # S3 bucket for Storage
 TC_AWS_STORAGE_ROOT_PATH = '{{ TC_AWS_STORAGE_ROOT_PATH | default('') }}' # S3 path prefix for Storage bucket
 
-TC_AWS_LOADER_BUCKET = '{{ TC_AWS_LOADER_BUCKET | default('') }}' #S3 bucket for loader
+TC_AWS_LOADER_BUCKET = '{{ TC_AWS_LOADER_BUCKET | default(None) }}' #S3 bucket for loader
 TC_AWS_LOADER_ROOT_PATH = '{{ TC_AWS_LOADER_ROOT_PATH | default('') }}' # S3 path prefix for Loader bucket
 
 TC_AWS_RESULT_STORAGE_BUCKET = '{{ TC_AWS_RESULT_STORAGE_BUCKET | default('') }}' # S3 bucket for result Storage


### PR DESCRIPTION
In order to support loading from multiple buckets the value for the loader has to be set to None rather than empty string which is evaluated as value and not passing validation.
Throwing an error like: Invalid bucket name "": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$"`

**Additional Info:**
relevant code in tc_aws repo:
https://github.com/thumbor-community/aws/blob/master/tc_aws/loaders/__init__.py#L21

related issue in this repo:
https://github.com/APSL/docker-thumbor/issues/55

