### PR TITLE
Updates the nginx base image to 1.13

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.11.5
+FROM nginx:1.13
 MAINTAINER Edu Herraiz <ghark@gmail.com>
 
 COPY nginx.conf /etc/nginx/


### PR DESCRIPTION
I did not add any subversion (`1.13.0`) to be able to get automatically security updates from nginx without any need to update the Dockerfile.