### PR TITLE
Bump tc-aws from 6.0.1 to 6.0.2

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,7 +7,7 @@ pyremotecv==0.5.0
 remotecv==2.2.1
 opencv-engine==1.0.1
 thumbor==6.0.1
-tc-aws==6.0.1
+tc-aws==6.0.2
 tc-core==0.3.0
 tc-shortener==0.2.2
 raven==5.15.0

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -7,7 +7,7 @@ pyremotecv==0.5.0
 remotecv==2.2.1
 opencv-engine==1.0.1
 thumbor==6.0.2
-tc-aws==6.0.1
+tc-aws==6.0.2
 tc-core==0.3.0
 tc-shortener==0.2.2
 raven==5.15.0


### PR DESCRIPTION
This allows the use of any S3 compatible cloud storage.