### PR TITLE
Fix docker login on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   #- DOCKER_VERSION=1.11.1-0~trusty
   - DOCKER_COMPOSE_VERSION=1.8.0
 after_success:
-- docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+- echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
 - docker push apsl/thumbor:$THUMBOR_VERSION
 - if [ "$TRAVIS_BRANCH" == "master" ]; then docker push apsl/thumbor:latest ; fi;
 - docker push apsl/thumbor:$THUMBOR_VERSION-simd-sse4


### PR DESCRIPTION
The `-e` option has been removed from docker login.

Command taken from https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry