### PR TITLE
dealing with format filter and cached files

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -48,7 +48,16 @@ http {
         default   "";                                                  # AUTO_WEBP
         "~*webp*"  "/webp";                                            # AUTO_WEBP
     }                                                                  # AUTO_WEBP
-        
+
+    map $request_uri $format {
+        default "";
+        "~*format\(jpeg\)" "image/jpeg";
+        "~*format\(jpg\)" "image/jpeg";
+        "~*format\(png\)" "image/png";
+        "~*format\(gif\)" "image/gif";
+        "~*format\(webp\)" "image/webp";
+    }
+
     upstream thumbor {
         server thumbor_host:thumbor_port;
     }
@@ -71,6 +80,9 @@ http {
             add_header Vary Accept;                                     # AUTO_WEBP
             error_page  404 = @fetch;
             
+            # if $format is empty (default) then this is ignored
+            add_header Content-Type $format;
+
             # Will be deleted if envvar THUMBOR_ALLOW_CONTENT_DISPOSITION != true
             if ($args ~* download){                                     # THUMBOR_ALLOW_CONTENT_DISPOSITION
                 add_header 'Content-Disposition' 'attachment';          # THUMBOR_ALLOW_CONTENT_DISPOSITION


### PR DESCRIPTION
* see https://github.com/thumbor/thumbor/issues/986
* nginx serves cached files if available. When this happens,
  nginx "guesses" the Content-Type based on the extension
* If you have a file that you force to a specific format
  (see https://github.com/thumbor/thumbor/wiki/Format)
  and the original file has a different extension
  (e.g. a `png` file with `format(jpeg)`), and the file
  is cached, then the `Content-Type` header would be wrong
* this fix checks whether the request uri contains `format(...)`
  with valid formats, and if it does, adds a `Content-Type` header
  matching the format
* By default, the format will be empty, and the added header is ignored