### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -100,9 +100,9 @@ http {
             }                                                                                                                         # THUMBOR_ALLOW_CONTENT_DISPOSITION
         }
 
-        location ~ /\.ht { deny  all; access_log off; error_log off; }
-        location ~ /\.hg { deny  all; access_log off; error_log off; }
-        location ~ /\.svn { deny  all; access_log off; error_log off; }
-        location = /favicon.ico { deny  all; access_log off; error_log off; }
+        location ~ /\.ht { deny  all; access_log /dev/null; error_log /dev/null; }
+        location ~ /\.hg { deny  all; access_log /dev/null; error_log /dev/null; }
+        location ~ /\.svn { deny  all; access_log /dev/null; error_log /dev/null; }
+        location = /favicon.ico { deny  all; access_log /dev/null; error_log /dev/null; }
     }
 }


### PR DESCRIPTION
Setting `error_log` to `off` will create a file named `off` in the directory where nginx is running.

See: https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/